### PR TITLE
Add edgetpu empty parameters

### DIFF
--- a/r2i/edgetpu/Makefile.am
+++ b/r2i/edgetpu/Makefile.am
@@ -17,7 +17,8 @@ tensorflowliteedgetpuincludedir = @R2IINCLUDEDIR@/r2i/edgetpu
 
 libedgetpu_la_SOURCES =                     \
     engine.cc                               \
-    frameworkfactory.cc 
+    frameworkfactory.cc                     \
+    parameters.cc 
 
 libedgetpu_la_CPPFLAGS =                    \
     $(RR_CPPFLAGS)                          \
@@ -43,6 +44,7 @@ libedgetpu_la_LIBADD =                      \
 
 tensorflowliteedgetpuinclude_HEADERS =      \
     engine.h                                \
-    frameworkfactory.h
+    frameworkfactory.h                      \
+    parameters.h
 
 endif # HAVE_EDGETPU

--- a/r2i/edgetpu/frameworkfactory.cc
+++ b/r2i/edgetpu/frameworkfactory.cc
@@ -11,6 +11,7 @@
 
 #include "frameworkfactory.h"
 #include "engine.h"
+#include "parameters.h"
 
 #include <libedgetpu/edgetpu.h>
 
@@ -22,6 +23,13 @@ std::unique_ptr<r2i::IEngine> FrameworkFactory::MakeEngine (
   error.Clean ();
 
   return std::unique_ptr<IEngine> (new Engine);
+}
+
+std::unique_ptr<r2i::IParameters> FrameworkFactory::MakeParameters (
+  RuntimeError &error) {
+  error.Clean ();
+
+  return std::unique_ptr<IParameters> (new Parameters);
 }
 
 r2i::FrameworkMeta FrameworkFactory::GetDescription (

--- a/r2i/edgetpu/frameworkfactory.h
+++ b/r2i/edgetpu/frameworkfactory.h
@@ -20,6 +20,7 @@ namespace edgetpu {
 class FrameworkFactory : public r2i::tflite::FrameworkFactory {
  public:
   std::unique_ptr<r2i::IEngine> MakeEngine (RuntimeError &error) override;
+  std::unique_ptr<r2i::IParameters> MakeParameters (RuntimeError &error) override;
 
   r2i::FrameworkMeta GetDescription (RuntimeError &error) override;
 };

--- a/r2i/edgetpu/meson.build
+++ b/r2i/edgetpu/meson.build
@@ -2,11 +2,13 @@
 edgetpu_sources = [
   'engine.cc',
   'frameworkfactory.cc',
+  'parameters.cc'
 ]
 
 edgetpu_headers = [
   'engine.h',
   'frameworkfactory.h',
+  'parameters.h'
 ]
 
 # Build library

--- a/r2i/edgetpu/parameters.cc
+++ b/r2i/edgetpu/parameters.cc
@@ -1,0 +1,73 @@
+/* Copyright (C) 2020 RidgeRun, LLC (http://www.ridgerun.com)
+ * All Rights Reserved.
+ *
+ * The contents of this software are proprietary and confidential to RidgeRun,
+ * LLC.  No part of this program may be photocopied, reproduced or translated
+ * into another programming language without prior written consent of
+ * RidgeRun, LLC.  The user is free to modify the source code after obtaining
+ * a software license from RidgeRun.  All source code changes must be provided
+ * back to RidgeRun without any encumbrance.
+*/
+
+#include "parameters.h"
+
+namespace r2i {
+namespace edgetpu {
+
+Parameters::Parameters() {}
+
+RuntimeError Parameters::Configure (std::shared_ptr < IEngine > in_engine,
+                                    std::shared_ptr < IModel > in_model) {
+  RuntimeError error;
+  return error;
+}
+
+std::shared_ptr < IEngine > Parameters::GetEngine () {
+  return nullptr;
+}
+
+std::shared_ptr < IModel > Parameters::GetModel () {
+  return nullptr;
+}
+
+RuntimeError Parameters::Get (const std::string &in_parameter, int &value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::Get (const std::string &in_parameter, double &value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::Get (const std::string &in_parameter,
+                              std::string &value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::Set (const std::string &in_parameter,
+                              const std::string &in_value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::Set (const std::string &in_parameter,
+                              int in_value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::Set (const std::string &in_parameter,
+                              double in_value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::List (std::vector < ParameterMeta > &metas) {
+  RuntimeError error;
+  return error;
+}
+
+}  // namespace edgetpu
+}  // namespace r2i

--- a/r2i/edgetpu/parameters.h
+++ b/r2i/edgetpu/parameters.h
@@ -1,0 +1,60 @@
+/* Copyright (C) 2020 RidgeRun, LLC (http://www.ridgerun.com)
+ * All Rights Reserved.
+ *
+ * The contents of this software are proprietary and confidential to RidgeRun,
+ * LLC.  No part of this program may be photocopied, reproduced or translated
+ * into another programming language without prior written consent of
+ * RidgeRun, LLC.  The user is free to modify the source code after obtaining
+ * a software license from RidgeRun.  All source code changes must be provided
+ * back to RidgeRun without any encumbrance.
+*/
+
+#ifndef R2I_EDGETPU_PARAMETERS_H
+#define R2I_EDGETPU_PARAMETERS_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <r2i/iparameters.h>
+#include <r2i/runtimeerror.h>
+#include <r2i/tflite/engine.h>
+#include <r2i/tflite/model.h>
+
+namespace r2i {
+namespace edgetpu {
+
+class Parameters: public IParameters {
+ public:
+  Parameters ();
+
+  RuntimeError Configure (std::shared_ptr < IEngine > in_engine,
+                          std::shared_ptr < IModel > in_model) override;
+
+  std::shared_ptr < IEngine > GetEngine () override;
+
+  std::shared_ptr < IModel > GetModel () override;
+
+  RuntimeError Get (const std::string &in_parameter, int &value) override;
+
+  RuntimeError Get (const std::string &in_parameter, double &value) override;
+
+  RuntimeError Get (const std::string &in_parameter,
+                    std::string &value) override;
+
+  RuntimeError Set (const std::string &in_parameter,
+                    const std::string &in_value) override;
+
+  RuntimeError Set (const std::string &in_parameter,
+                    int in_value) override;
+
+  RuntimeError Set (const std::string &in_parameter, double in_value) override;
+
+  RuntimeError List (std::vector < ParameterMeta > &metas) override;
+
+};
+
+}  // namespace edgetpu
+}  // namespace r2i
+
+#endif //R2I_EDGETPU_PARAMETERS_H


### PR DESCRIPTION
This is a workaround to avoid the warning that we get when loading the get inference plugings.