### PR TITLE
Feature/enable base onnxrt backend for execution providers

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -50,6 +50,11 @@ RR_CHECK_FEATURE_LIB(TENSORFLOW, TensorFlow Installation,
                      tensorflow, TF_Version, tensorflow/c/c_api.h, no)
 
 AC_LANG_PUSH([C++])
+
+if test x$enable_edgetpu = xyes; then
+    enable_tflite=yes
+fi
+
 RR_CHECK_FEATURE_LIB(EDGETPU, EdgeTPU with TensorFlow lite Installation,
                      :libedgetpu.so.1.0, edgetpu_version, edgetpu.h, no)
 
@@ -59,11 +64,13 @@ RR_CHECK_FEATURE_LIB(TFLITE, TensorFlow lite Installation,
 # add specific LIBS for TFLITE
 AC_SUBST([TFLITE_LIBS], ["$TFLITE_LIBS -pthread -ldl -lrt"])
 
-AM_COND_IF([HAVE_EDGETPU], [AM_COND_IF([HAVE_TFLITE], [],
- [AC_MSG_ERROR(The EdgeTPU backend needs TFLITE enabled as well. Please enable it with enable-tflite option)])], [])
-
 RR_CHECK_FEATURE_LIB(TENSORRT, TensorRT Installation,
                      nvinfer, createInferBuilder_INTERNAL, NvInfer.h, no)
+
+# ONNXRT backend
+if test x$enable_onnxrt_acl = xyes || test x$enable_onnxrt_openvino = xyes; then
+    enable_onnxrt=yes
+fi
 
 RR_CHECK_FEATURE_LIB(ONNXRT, ONNX Runtime Installation,
                      onnxruntime, OrtGetApiBase, onnxruntime/core/session/onnxruntime_cxx_api.h, no)
@@ -72,9 +79,6 @@ RR_CHECK_FEATURE_LIB(ONNXRT_ACL, ONNX Runtime Installation with Arm Compute Libr
                      onnxruntime, OrtSessionOptionsAppendExecutionProvider_ACL, onnxruntime/core/providers/acl/acl_provider_factory.h, no)
 
 if test x$enable_onnxrt_acl = xyes; then
-    AC_MSG_NOTICE([Building the ONNXRT backend with ACL support])
-    AM_COND_IF([HAVE_ONNXRT_ACL], [AM_COND_IF([HAVE_ONNXRT], [],
-     [AC_MSG_ERROR(The ONNXRT ACL support needs ONNXRT backend enabled aswell. Please enable it with enable-onnxrt option)])], [])
     AC_CHECK_LIB(arm_compute, _init, [], [AC_MSG_ERROR(Can not find Arm Compute Library dependencies)], [])
     AC_CHECK_LIB(arm_compute_core, _init, [], [AC_MSG_ERROR(Can not find Arm Compute Library dependencies)], [])
     AC_CHECK_LIB(arm_compute_graph, _init, [], [AC_MSG_ERROR(Can not find Arm Compute Library dependencies)], [])
@@ -83,8 +87,6 @@ fi
 
 RR_CHECK_FEATURE_LIB(ONNXRT_OPENVINO, ONNX Runtime Installation with OpenVINO support,
                      onnxruntime, OrtSessionOptionsAppendExecutionProvider_OpenVINO, onnxruntime/core/providers/openvino/openvino_provider_factory.h, no)
-AM_COND_IF([HAVE_ONNXRT_OPENVINO], [AM_COND_IF([HAVE_ONNXRT], [],
- [AC_MSG_ERROR(The ONNXRT OpenVINO support needs ONNXRT backend enabled aswell. Please enable it with enable-onnxrt option)])], [])
 
 AC_LANG_POP([C++])
 

--- a/examples/r2i/meson.build
+++ b/examples/r2i/meson.build
@@ -13,30 +13,30 @@ foreach app : app_examples
     install: false)
 endforeach
 
-if get_option('enable-edgetpu')
+if cdata.get('HAVE_EDGETPU') == true
   subdir('edgetpu')
 endif
 
-if get_option('enable-onnxrt')
+if cdata.get('HAVE_ONNXRT') == true
   subdir('onnxrt')
 endif
 
-if get_option('enable-onnxrt-acl')
+if cdata.get('HAVE_ONNXRT_ACL') == true
   subdir('onnxrt_acl')
 endif
 
-if get_option('enable-onnxrt-openvino')
+if cdata.get('HAVE_ONNXRT_OPENVINO') == true
   subdir('onnxrt_openvino')
 endif
 
-if get_option('enable-tensorflow')
+if cdata.get('HAVE_TENSORFLOW') == true
   subdir('tensorflow')
 endif
 
-if get_option('enable-tflite')
+if cdata.get('HAVE_TFLITE') == true
   subdir('tflite')
 endif
 
-if get_option('enable-tensorrt')
+if cdata.get('HAVE_TENSORRT') == true
   subdir('tensorrt')
 endif

--- a/meson.build
+++ b/meson.build
@@ -27,37 +27,41 @@ cpp_args = ['-DHAVE_CONFIG_H']
 # Create an empty configuration object to set config.h information
 cdata = configuration_data()
 
+# Initialize preprocessor definitions
+cdata.set('HAVE_TENSORFLOW', false)
+cdata.set('HAVE_TFLITE', false)
+cdata.set('HAVE_EDGETPU', false)
+cdata.set('HAVE_TENSORRT', false)
+cdata.set('HAVE_ONNXRT', false)
+cdata.set('HAVE_ONNXRT_ACL', false)
+cdata.set('HAVE_ONNXRT_OPENVINO', false)
+
 # Define library dependencies for Tensorflow support
 if get_option('enable-tensorflow')
   tensorflow = cpp.find_library('tensorflow', required: true)
   tensorflow_dep = declare_dependency(dependencies: tensorflow)
   lib_tf_dep = [tensorflow_dep]
-  cdata.set('HAVE_TENSORFLOW', 1)
+  cdata.set('HAVE_TENSORFLOW', true)
 endif
 
 # Define library dependencies for Tensorflow Lite support
-if get_option('enable-tflite')
+if get_option('enable-tflite') or get_option('enable-edgetpu')
   tensorflow_lite = cpp.find_library('tensorflow-lite', required: true)
   tensorflow_lite_dep = declare_dependency(dependencies: tensorflow_lite)
   thread_dep = dependency('threads')
   lib_tflite_dep = [tensorflow_lite_dep, thread_dep]
-  cdata.set('HAVE_TFLITE', 1)
+  cdata.set('HAVE_TFLITE', true)
 endif
 
 # Define library dependencies for Tensorflow Lite support
 if get_option('enable-edgetpu')
-  if get_option('enable-tflite')
     edgetpu = cpp.find_library(':libedgetpu.so.1.0', required: true)
     edgetpu_dep = declare_dependency(dependencies: edgetpu)
     thread_dep = dependency('threads')
     dl_dep = cpp.find_library('dl', required : true)
     rt_dep = cpp.find_library('rt', required : true)
     lib_edgetpu_dep = [edgetpu_dep, lib_tflite_dep, dl_dep, rt_dep]
-    cdata.set('HAVE_EDGETPU', 1)
-  else
-    error('''The EdgeTPU needs to have the TFLite backend enabled as well.
-    Please enable it with enable-tflite option''')
-  endif
+    cdata.set('HAVE_EDGETPU', true)
 endif
 
 # Define library dependencies for TensorRT support
@@ -86,48 +90,39 @@ if get_option('enable-tensorrt')
   tensorrt = cpp.find_library('nvinfer', required: true)
   tensorrt_dep = declare_dependency(dependencies: tensorrt)
   lib_trt_dep = [tensorrt_dep, cuda_dep, cudart_dep]
-  cdata.set('HAVE_TENSORRT', 1)
+  cdata.set('HAVE_TENSORRT', true)
 endif
 
 # Define library dependencies for ONNX support
-if get_option('enable-onnxrt')
+if get_option('enable-onnxrt') or get_option('enable-onnxrt-acl') or get_option('enable-onnxrt-openvino')
   onnxrt = cpp.find_library('onnxruntime', required: true)
   onnxrt_dep = declare_dependency(dependencies: onnxrt)
   lib_onnxrt_dep = [onnxrt_dep]
-  cdata.set('HAVE_ONNXRT', 1)
+  cdata.set('HAVE_ONNXRT', true)
 endif
 
 # Define library dependencies for ONNXRT with ACL execution provider support
 if get_option('enable-onnxrt-acl')
-  if get_option('enable-onnxrt')
-    arm_compute = cpp.find_library('arm_compute', required: true)
-    arm_compute_dep = declare_dependency(dependencies: arm_compute)
-    arm_compute_core = cpp.find_library('arm_compute_core', required: true)
-    arm_compute_core_dep = declare_dependency(dependencies: arm_compute_core)
-    arm_compute_graph = cpp.find_library('arm_compute_graph', required: true)
-    arm_compute_graph_dep = declare_dependency(dependencies: arm_compute_graph)
-    lib_onnxrt_acl_dep = [arm_compute_dep, arm_compute_core_dep, arm_compute_graph_dep, lib_onnxrt_dep]
-    lib_onnxrt_dep += [lib_onnxrt_acl_dep]
-    cdata.set('HAVE_ONNXRT_ACL', 1)
-  else
-    error('''The ACL execution provider support requires ONNXRT enabled aswell.
-     Please enable it with enable-onnxrt option''')
-  endif
+  arm_compute = cpp.find_library('arm_compute', required: true)
+  arm_compute_dep = declare_dependency(dependencies: arm_compute)
+  arm_compute_core = cpp.find_library('arm_compute_core', required: true)
+  arm_compute_core_dep = declare_dependency(dependencies: arm_compute_core)
+  arm_compute_graph = cpp.find_library('arm_compute_graph', required: true)
+  arm_compute_graph_dep = declare_dependency(dependencies: arm_compute_graph)
+  lib_onnxrt_acl_dep = [arm_compute_dep, arm_compute_core_dep, arm_compute_graph_dep, lib_onnxrt_dep]
+  lib_onnxrt_dep += [lib_onnxrt_acl_dep]
+  cdata.set('HAVE_ONNXRT_ACL', true)
 endif
 
 # Define library dependencies for ONNXRT with OpenVINO execution provider support
 if get_option('enable-onnxrt-openvino')
-  if get_option('enable-onnxrt')
-    cdata.set('HAVE_ONNXRT_OPENVINO', 1)
-  else
-    error('''The OpenVINO execution provider support requires ONNXRT enabled aswell.
-     Please enable it with enable-onnxrt option''')
-  endif
+  cdata.set('HAVE_ONNXRT_OPENVINO', true)
 endif
 
 # Check if at least one backend is enabled
-if not (cdata.has('HAVE_TENSORFLOW') or cdata.has('HAVE_TFLITE') or
-        cdata.has('HAVE_TENSORRT') or cdata.has('HAVE_ONNXRT'))
+if (cdata.get('HAVE_TENSORFLOW') == false and cdata.get('HAVE_TFLITE') == false and
+        cdata.get('HAVE_TENSORRT') == false and cdata.get('HAVE_ONNXRT') == false and
+        cdata.get('HAVE_ONNXRT_ACL') == false and cdata.get('HAVE_ONNXRT_OPENVINO') == false)
   error ('No backend selected, you must choose at least one')
 endif
 

--- a/r2i/meson.build
+++ b/r2i/meson.build
@@ -1,36 +1,36 @@
 r2inference_internal_dep = []
 
-if get_option('enable-tensorflow')
+if cdata.get('HAVE_TENSORFLOW') == true
   subdir('tensorflow')
   r2inference_internal_dep = [internal_tf_dep]
 endif
 
-if get_option('enable-tflite')
+if cdata.get('HAVE_TFLITE') == true
   subdir('tflite')
   r2inference_internal_dep += [internal_tflite_dep]
 endif
 
-if get_option('enable-edgetpu')
+if cdata.get('HAVE_EDGETPU') == true
   subdir('edgetpu')
   r2inference_internal_dep += [internal_edgetpu_dep]
 endif
 
-if get_option('enable-tensorrt')
+if cdata.get('HAVE_TENSORRT') == true
   subdir('tensorrt')
   r2inference_internal_dep += [internal_trt_dep]
 endif
 
-if get_option('enable-onnxrt')
+if cdata.get('HAVE_ONNXRT') == true
   subdir('onnxrt')
   r2inference_internal_dep += [internal_onnxrt_dep]
 endif
 
-if get_option('enable-onnxrt-acl')
+if cdata.get('HAVE_ONNXRT_ACL') == true
   subdir('onnxrt_acl')
   r2inference_internal_dep += [internal_onnxrt_acl_dep]
 endif
 
-if get_option('enable-onnxrt-openvino')
+if cdata.get('HAVE_ONNXRT_OPENVINO') == true
   subdir('onnxrt_openvino')
   r2inference_internal_dep += [internal_onnxrt_openvino_dep]
 endif

--- a/tests/unit/r2i/meson.build
+++ b/tests/unit/r2i/meson.build
@@ -16,18 +16,18 @@ foreach t : lib_r2inference_tests
 
 endforeach
 
-if get_option('enable-onnxrt')
+if cdata.get('HAVE_ONNXRT') == true
   subdir('onnxrt')
 endif
 
-if get_option('enable-tensorflow')
+if cdata.get('HAVE_TENSORFLOW') == true
   subdir('tensorflow')
 endif
 
-if get_option('enable-tflite')
+if cdata.get('HAVE_TFLITE') == true
   subdir('tflite')
 endif
 
-if get_option('enable-tensorrt')
+if cdata.get('HAVE_TENSORRT') == true
   subdir('tensorrt')
 endif


### PR DESCRIPTION
This feature intends to enable ONNXRT base backend automatically when building for a specific execution provider. Same solution applied on the EdgeTPU backend.