### PR TITLE
Feature/add onnxrt openvino hardware id parameter

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -128,6 +128,7 @@ tests/unit/Makefile
 tests/unit/r2i/Makefile
 tests/unit/r2i/ncsdk/Makefile
 tests/unit/r2i/onnxrt/Makefile
+tests/unit/r2i/onnxrt_openvino/Makefile
 tests/unit/r2i/tensorflow/Makefile
 tests/unit/r2i/tensorrt/Makefile
 tests/unit/r2i/tflite/Makefile

--- a/r2i/onnxrt/engine.cc
+++ b/r2i/onnxrt/engine.cc
@@ -82,8 +82,9 @@ void Engine::CreateSessionOptions() {
     this->graph_opt_level);
 }
 
-void Engine::AppendSessionOptionsExecutionProvider(Ort::SessionOptions
-    &session_options, r2i::RuntimeError &error) {
+void Engine::AppendSessionOptionsExecutionProvider(
+  Ort::SessionOptions &session_options,
+  r2i::RuntimeError &error) {
 
   /* No implementation needed to use default CPU execution provider */
 
@@ -186,8 +187,9 @@ RuntimeError Engine::Stop () {
   return error;
 }
 
-std::shared_ptr<r2i::IPrediction> Engine::Predict (std::shared_ptr<r2i::IFrame>
-    in_frame, r2i::RuntimeError &error) {
+std::shared_ptr<r2i::IPrediction> Engine::Predict (
+  std::shared_ptr<r2i::IFrame> in_frame,
+  r2i::RuntimeError &error) {
   ImageFormat frame_format;
   int frame_width = 0;
   int frame_height = 0;
@@ -261,7 +263,9 @@ size_t Engine::GetSessionOutputCount(std::shared_ptr<Ort::Session> session,
 }
 
 std::vector<int64_t> Engine::GetSessionInputNodeDims(
-  std::shared_ptr<Ort::Session> session, size_t index, RuntimeError &error) {
+  std::shared_ptr<Ort::Session> session,
+  size_t index,
+  RuntimeError &error) {
   std::vector<int64_t> dims;
   if (nullptr == session) {
     error.Set (RuntimeError::Code:: NULL_PARAMETER,
@@ -305,9 +309,10 @@ const char *Engine::GetSessionInputName(std::shared_ptr<Ort::Session> session,
   return name;
 }
 
-const char *Engine::GetSessionOutputName(std::shared_ptr<Ort::Session> session,
-    size_t index, OrtAllocator *allocator,
-    RuntimeError &error) {
+const char *Engine::GetSessionOutputName(
+  std::shared_ptr<Ort::Session> session,
+  size_t index, OrtAllocator *allocator,
+  RuntimeError &error) {
   const char *name = "";
 
   if (nullptr == session) {
@@ -350,8 +355,10 @@ RuntimeError Engine::GetSessionInfo(std::shared_ptr<Ort::Session> session,
   return error;
 }
 
-RuntimeError Engine::ValidateInputTensorShape (int channels, int height,
-    int width, std::vector<int64_t> input_dims) {
+RuntimeError Engine::ValidateInputTensorShape (
+  int channels, int height,
+  int width,
+  std::vector<int64_t> input_dims) {
   RuntimeError error;
 
   /* We only support 1 batch */

--- a/r2i/onnxrt/engine.cc
+++ b/r2i/onnxrt/engine.cc
@@ -28,7 +28,7 @@ namespace onnxrt {
 Engine::Engine () {
   /* Initialize all variable members */
   logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
-  intra_num_threads = 1;
+  intra_num_threads = 0;
   graph_opt_level = GraphOptimizationLevel::ORT_DISABLE_ALL;
   log_id = "";
   state = State::STOPPED;

--- a/r2i/onnxrt/engine.cc
+++ b/r2i/onnxrt/engine.cc
@@ -28,6 +28,7 @@ namespace onnxrt {
 Engine::Engine () {
   /* Initialize all variable members */
   logging_level = OrtLoggingLevel::ORT_LOGGING_LEVEL_WARNING;
+  /*Better overall default performance when intra_num_threads = 0*/
   intra_num_threads = 0;
   graph_opt_level = GraphOptimizationLevel::ORT_DISABLE_ALL;
   log_id = "";

--- a/r2i/onnxrt/engine.h
+++ b/r2i/onnxrt/engine.h
@@ -34,7 +34,8 @@ class Engine : public IEngine {
   r2i::RuntimeError Start () override;
   r2i::RuntimeError Stop () override;
   std::shared_ptr<r2i::IPrediction> Predict (std::shared_ptr<r2i::IFrame>
-      in_frame, r2i::RuntimeError &error) override;
+      in_frame,
+      r2i::RuntimeError &error) override;
   r2i::RuntimeError SetLoggingLevel (int logging_level);
   r2i::RuntimeError SetLogId (const std::string &log_id);
   r2i::RuntimeError SetIntraNumThreads (int intra_num_threads);
@@ -70,31 +71,33 @@ class Engine : public IEngine {
   size_t GetSessionOutputCount(std::shared_ptr<Ort::Session> session,
                                RuntimeError &error);
   std::vector<int64_t> GetSessionInputNodeDims(std::shared_ptr<Ort::Session>
-      session, size_t index, RuntimeError &error);
+      session,
+      size_t index,
+      RuntimeError &error);
   size_t GetSessionOutputSize(std::shared_ptr<Ort::Session> session,
                               size_t index, RuntimeError &error);
   const char *GetSessionInputName(std::shared_ptr<Ort::Session> session,
-                                  size_t index,
-                                  OrtAllocator *allocator, RuntimeError &error);
+                                  size_t index, OrtAllocator *allocator,
+                                  RuntimeError &error);
   const char *GetSessionOutputName(std::shared_ptr<Ort::Session> session,
-                                   size_t index,
-                                   OrtAllocator *allocator, RuntimeError &error);
-  float *SessionRun (std::shared_ptr<Ort::Session> session,
-                     std::shared_ptr<Frame> frame,
-                     size_t input_image_size,
-                     std::vector<int64_t> input_node_dims,
-                     std::vector<Ort::Value> &output_tensor,
-                     RuntimeError &error);
+                                   size_t index, OrtAllocator *allocator,
+                                   RuntimeError &error);
+  float *SessionRun(std::shared_ptr<Ort::Session> session,
+                    std::shared_ptr<Frame> frame,
+                    size_t input_image_size,
+                    std::vector<int64_t> input_node_dims,
+                    std::vector<Ort::Value> &output_tensor,
+                    RuntimeError &error);
   r2i::RuntimeError GetSessionInfo(std::shared_ptr<Ort::Session> session,
                                    size_t index);
-  r2i::RuntimeError ValidateInputTensorShape (int channels, int height, int width,
+  r2i::RuntimeError ValidateInputTensorShape(int channels, int height, int width,
       std::vector<int64_t> input_dims);
-  r2i::RuntimeError ScoreModel (std::shared_ptr<Ort::Session> session,
-                                std::shared_ptr<Frame> frame,
-                                size_t input_size,
-                                size_t output_size,
-                                std::vector<int64_t> input_node_dims,
-                                std::shared_ptr<Prediction> prediction);
+  r2i::RuntimeError ScoreModel(std::shared_ptr<Ort::Session> session,
+                               std::shared_ptr<Frame> frame,
+                               size_t input_size,
+                               size_t output_size,
+                               std::vector<int64_t> input_node_dims,
+                               std::shared_ptr<Prediction> prediction);
 
  protected:
   enum State {
@@ -104,7 +107,8 @@ class Engine : public IEngine {
   State state;
 
   virtual void AppendSessionOptionsExecutionProvider(Ort::SessionOptions
-      &session_options, r2i::RuntimeError &error);
+      &session_options,
+      r2i::RuntimeError &error);
 
 };
 

--- a/r2i/onnxrt/parameters.cc
+++ b/r2i/onnxrt/parameters.cc
@@ -89,7 +89,8 @@ std::shared_ptr<r2i::IModel> Parameters::GetModel () {
 }
 
 Parameters::ParamDesc Parameters::Validate (const std::string &in_parameter,
-    int type, const std::string &stype, RuntimeError &error) {
+    int type, const std::string &stype,
+    RuntimeError &error) {
   ParamDesc undefined = {{.name = "", .description = ""}, nullptr};
 
   error.Clean ();

--- a/r2i/onnxrt/parameters.cc
+++ b/r2i/onnxrt/parameters.cc
@@ -16,40 +16,33 @@
 namespace r2i {
 namespace onnxrt {
 
-#define PARAM(_name, _desc, _flags, _type, _acc) \
-  {						 \
-    (_name),					 \
-    {						 \
-      .meta = {					 \
-	.name = (_name),			 \
-	.description = (_desc),			 \
-	.flags = (_flags),			 \
-	.type = (_type),			 \
-      },					 \
-      .accessor = (_acc)			 \
-    }						 \
-  }
+Parameters::Parameters () {
+  ParamDesc logging_level_desc = {
+    {logging_level_meta},
+    std::make_shared<LoggingLevelAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(logging_level_meta.name,
+                                       logging_level_desc));
 
-Parameters::Parameters () :
-  parameter_map ({
-  /* Engine parameters */
-  PARAM("logging-level", "ONNXRT Logging Level",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::INTEGER,
-        std::make_shared<LoggingLevelAccessor>(this)),
-  PARAM("log-id", "String identification for ONNXRT environment",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::STRING,
-        std::make_shared<LogIdAccessor>(this)),
-  PARAM("intra-num-threads", "Number of threads to parallelize execution within model nodes",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::INTEGER,
-        std::make_shared<IntraNumThreadsAccessor>(this)),
-  PARAM("graph-optimization-level", "ONNXRT graph optimization level",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::INTEGER,
-        std::make_shared<GraphOptLevelAccessor>(this)),
-}) {
+  ParamDesc log_id_desc = {
+    {log_id_meta},
+    std::make_shared<LogIdAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(log_id_meta.name, log_id_desc));
+
+  ParamDesc intra_num_threads_desc = {
+    {intra_num_threads_meta},
+    std::make_shared<IntraNumThreadsAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(intra_num_threads_meta.name,
+                                       intra_num_threads_desc));
+
+  ParamDesc graph_optimization_level_desc = {
+    {graph_optimization_level_meta},
+    std::make_shared<GraphOptLevelAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(graph_optimization_level_meta.name,
+                                       graph_optimization_level_desc));
 }
 
 RuntimeError Parameters::Configure (std::shared_ptr<r2i::IEngine> in_engine,

--- a/r2i/onnxrt/parameters.cc
+++ b/r2i/onnxrt/parameters.cc
@@ -62,14 +62,14 @@ RuntimeError Parameters::Configure (std::shared_ptr<r2i::IEngine> in_engine,
   auto engine = std::dynamic_pointer_cast<Engine, IEngine>(in_engine);
   if (nullptr == engine) {
     error.Set (RuntimeError::Code::INCOMPATIBLE_ENGINE,
-               "The provided engine is not an onnxrt engine");
+               "The provided engine is not an ONNXRT engine");
     return error;
   }
 
   auto model = std::dynamic_pointer_cast<Model, IModel>(in_model);
   if (nullptr == model) {
     error.Set (RuntimeError::Code::INCOMPATIBLE_MODEL,
-               "The provided engine is not an onnxrt model");
+               "The provided engine is not an ONNXRT model");
     return error;
   }
 

--- a/r2i/onnxrt/parameters.h
+++ b/r2i/onnxrt/parameters.h
@@ -131,11 +131,36 @@ class Parameters: public IParameters {
   };
 
   typedef std::unordered_map<std::string, ParamDesc> ParamMap;
-  const ParamMap parameter_map;
+  ParamMap parameter_map;
 
   ParamDesc Validate (const std::string &in_parameter, int type,
                       const std::string &stype, RuntimeError &error);
 
+ protected:
+  ParameterMeta logging_level_meta = {
+    .name = "logging-level",
+    .description = "ONNXRT Logging Level",
+    .flags = r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+    .type = r2i::ParameterMeta::Type::INTEGER
+  };
+  ParameterMeta log_id_meta = {
+    .name = "log-id",
+    .description = "String identification for ONNXRT environment",
+    .flags = r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+    .type = r2i::ParameterMeta::Type::STRING
+  };
+  ParameterMeta intra_num_threads_meta = {
+    .name = "intra-num-threads",
+    .description = "Number of threads to parallelize execution within model nodes",
+    .flags = r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+    .type = r2i::ParameterMeta::Type::INTEGER
+  };
+  ParameterMeta graph_optimization_level_meta = {
+    .name = "graph-optimization-level",
+    .description = "ONNXRT graph optimization level",
+    .flags = r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+    .type = r2i::ParameterMeta::Type::INTEGER
+  };
 };
 
 }  // namespace onnxrt

--- a/r2i/onnxrt/parameters.h
+++ b/r2i/onnxrt/parameters.h
@@ -43,7 +43,6 @@ class Parameters: public IParameters {
 
  private:
   std::shared_ptr <Engine> engine;
-  std::shared_ptr <Model> model;
 
   friend class Accessor;
 
@@ -137,6 +136,8 @@ class Parameters: public IParameters {
                       const std::string &stype, RuntimeError &error);
 
  protected:
+  std::shared_ptr <Model> model;
+
   ParameterMeta logging_level_meta = {
     .name = "logging-level",
     .description = "ONNXRT Logging Level",

--- a/r2i/onnxrt/parameters.h
+++ b/r2i/onnxrt/parameters.h
@@ -53,7 +53,7 @@ class Parameters: public IParameters {
     virtual RuntimeError Get () = 0;
     virtual ~Accessor() {}
 
-   public:
+   protected:
     Parameters *target;
   };
 

--- a/r2i/onnxrt_openvino/Makefile.am
+++ b/r2i/onnxrt_openvino/Makefile.am
@@ -17,7 +17,8 @@ onnxrt_openvinoincludedir = @R2IINCLUDEDIR@/r2i/onnxrt_openvino
 
 libonnxrt_openvino_la_SOURCES =             \
     engine.cc                               \
-    frameworkfactory.cc 
+    frameworkfactory.cc                     \
+    parameters.cc
 
 libonnxrt_openvino_la_CPPFLAGS =            \
     $(RR_CPPFLAGS)                          \
@@ -43,6 +44,7 @@ libonnxrt_openvino_la_LIBADD =              \
 
 onnxrt_openvinoinclude_HEADERS =            \
     engine.h                                \
-    frameworkfactory.h
+    frameworkfactory.h                      \
+    parameters.h
 
 endif # HAVE_ONNXRT_OPENVINO

--- a/r2i/onnxrt_openvino/engine.cc
+++ b/r2i/onnxrt_openvino/engine.cc
@@ -23,7 +23,8 @@ Engine::Engine () : onnxrt::Engine() {
 }
 
 void Engine::AppendSessionOptionsExecutionProvider(Ort::SessionOptions
-    &session_options, r2i::RuntimeError &error) {
+    &session_options,
+    r2i::RuntimeError &error) {
   OrtStatus *status = NULL;
   error.Clean ();
 

--- a/r2i/onnxrt_openvino/frameworkfactory.cc
+++ b/r2i/onnxrt_openvino/frameworkfactory.cc
@@ -11,6 +11,7 @@
 
 #include "frameworkfactory.h"
 #include "engine.h"
+#include "parameters.h"
 
 namespace r2i {
 namespace onnxrt_openvino {
@@ -20,6 +21,13 @@ std::unique_ptr<r2i::IEngine> FrameworkFactory::MakeEngine (
   error.Clean ();
 
   return std::unique_ptr<IEngine> (new Engine);
+}
+
+std::unique_ptr<r2i::IParameters> FrameworkFactory::MakeParameters (
+  RuntimeError &error) {
+  error.Clean ();
+
+  return std::unique_ptr<IParameters> (new Parameters);
 }
 
 r2i::FrameworkMeta FrameworkFactory::GetDescription (

--- a/r2i/onnxrt_openvino/frameworkfactory.h
+++ b/r2i/onnxrt_openvino/frameworkfactory.h
@@ -20,6 +20,7 @@ namespace onnxrt_openvino {
 class FrameworkFactory : public r2i::onnxrt::FrameworkFactory {
  public:
   std::unique_ptr<r2i::IEngine> MakeEngine (RuntimeError &error) override;
+  std::unique_ptr<r2i::IParameters> MakeParameters (RuntimeError &error) override;
 
   r2i::FrameworkMeta GetDescription (RuntimeError &error) override;
 };

--- a/r2i/onnxrt_openvino/meson.build
+++ b/r2i/onnxrt_openvino/meson.build
@@ -2,11 +2,13 @@
 onnxrt_openvino_sources = [
   'engine.cc',
   'frameworkfactory.cc',
+  'parameters.cc',
 ]
 
 onnxrt_openvino_headers = [
   'engine.h',
   'frameworkfactory.h',
+  'parameters.h',
 ]
 
 # Build library

--- a/r2i/onnxrt_openvino/parameters.cc
+++ b/r2i/onnxrt_openvino/parameters.cc
@@ -90,7 +90,9 @@ std::shared_ptr<r2i::IEngine> Parameters::GetEngine () {
 }
 
 Parameters::ParamDesc Parameters::Validate (const std::string &in_parameter,
-    int type, const std::string &stype, RuntimeError &error) {
+    int type,
+    const std::string &stype,
+    RuntimeError &error) {
   ParamDesc undefined = {{.name = "", .description = ""}, nullptr};
 
   error.Clean ();

--- a/r2i/onnxrt_openvino/parameters.cc
+++ b/r2i/onnxrt_openvino/parameters.cc
@@ -89,11 +89,6 @@ std::shared_ptr<r2i::IEngine> Parameters::GetEngine () {
   return this->engine;
 }
 
-
-std::shared_ptr<r2i::IModel> Parameters::GetModel () {
-  return this->model;
-}
-
 Parameters::ParamDesc Parameters::Validate (const std::string &in_parameter,
     int type, const std::string &stype, RuntimeError &error) {
   ParamDesc undefined = {{.name = "", .description = ""}, nullptr};

--- a/r2i/onnxrt_openvino/parameters.cc
+++ b/r2i/onnxrt_openvino/parameters.cc
@@ -68,14 +68,14 @@ RuntimeError Parameters::Configure (std::shared_ptr<r2i::IEngine> in_engine,
   auto engine = std::dynamic_pointer_cast<Engine, IEngine>(in_engine);
   if (nullptr == engine) {
     error.Set (RuntimeError::Code::INCOMPATIBLE_ENGINE,
-               "The provided engine is not an onnxrt engine");
+               "The provided engine is not an ONNXRT engine");
     return error;
   }
 
   auto model = std::dynamic_pointer_cast<onnxrt::Model, IModel>(in_model);
   if (nullptr == model) {
     error.Set (RuntimeError::Code::INCOMPATIBLE_MODEL,
-               "The provided engine is not an onnxrt model");
+               "The provided engine is not an ONNXRT model");
     return error;
   }
 

--- a/r2i/onnxrt_openvino/parameters.cc
+++ b/r2i/onnxrt_openvino/parameters.cc
@@ -16,44 +16,39 @@
 namespace r2i {
 namespace onnxrt_openvino {
 
-#define PARAM(_name, _desc, _flags, _type, _acc) \
-  {						 \
-    (_name),					 \
-    {						 \
-      .meta = {					 \
-	.name = (_name),			 \
-	.description = (_desc),			 \
-	.flags = (_flags),			 \
-	.type = (_type),			 \
-      },					 \
-      .accessor = (_acc)			 \
-    }						 \
-  }
+Parameters::Parameters () {
+  ParamDesc logging_level_desc = {
+    {logging_level_meta},
+    std::make_shared<LoggingLevelAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(logging_level_meta.name,
+                                       logging_level_desc));
 
-Parameters::Parameters () :
-  parameter_map ({
-  /* Engine parameters */
-  PARAM("logging-level", "ONNXRT Logging Level",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::INTEGER,
-        std::make_shared<LoggingLevelAccessor>(this)),
-  PARAM("log-id", "String identification for ONNXRT environment",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::STRING,
-        std::make_shared<LogIdAccessor>(this)),
-  PARAM("intra-num-threads", "Number of threads to parallelize execution within model nodes",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::INTEGER,
-        std::make_shared<IntraNumThreadsAccessor>(this)),
-  PARAM("graph-optimization-level", "ONNXRT graph optimization level",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::INTEGER,
-        std::make_shared<GraphOptLevelAccessor>(this)),
-  PARAM("hardware-id", "OpenVINO hardware device id",
-        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
-        r2i::ParameterMeta::Type::STRING,
-        std::make_shared<HardwareIdAccessor>(this)),
-}) {
+  ParamDesc log_id_desc = {
+    {log_id_meta},
+    std::make_shared<LogIdAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(log_id_meta.name, log_id_desc));
+
+  ParamDesc intra_num_threads_desc = {
+    {intra_num_threads_meta},
+    std::make_shared<IntraNumThreadsAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(intra_num_threads_meta.name,
+                                       intra_num_threads_desc));
+
+  ParamDesc graph_optimization_level_desc = {
+    {graph_optimization_level_meta},
+    std::make_shared<GraphOptLevelAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(graph_optimization_level_meta.name,
+                                       graph_optimization_level_desc));
+
+  ParamDesc hardware_id_desc = {
+    {hardware_id_meta},
+    std::make_shared<HardwareIdAccessor>(this)
+  };
+  parameter_map.emplace(std::make_pair(hardware_id_meta.name, hardware_id_desc));
 }
 
 RuntimeError Parameters::Configure (std::shared_ptr<r2i::IEngine> in_engine,

--- a/r2i/onnxrt_openvino/parameters.cc
+++ b/r2i/onnxrt_openvino/parameters.cc
@@ -1,0 +1,226 @@
+/* Copyright (C) 2020 RidgeRun, LLC (http://www.ridgerun.com)
+ * All Rights Reserved.
+ *
+ * The contents of this software are proprietary and confidential to RidgeRun,
+ * LLC.  No part of this program may be photocopied, reproduced or translated
+ * into another programming language without prior written consent of
+ * RidgeRun, LLC.  The user is free to modify the source code after obtaining
+ * a software license from RidgeRun.  All source code changes must be provided
+ * back to RidgeRun without any encumbrance.
+ */
+
+#include "parameters.h"
+
+#include <string>
+
+namespace r2i {
+namespace onnxrt_openvino {
+
+#define PARAM(_name, _desc, _flags, _type, _acc) \
+  {						 \
+    (_name),					 \
+    {						 \
+      .meta = {					 \
+	.name = (_name),			 \
+	.description = (_desc),			 \
+	.flags = (_flags),			 \
+	.type = (_type),			 \
+      },					 \
+      .accessor = (_acc)			 \
+    }						 \
+  }
+
+Parameters::Parameters () :
+  parameter_map ({
+  /* Engine parameters */
+  PARAM("logging-level", "ONNXRT Logging Level",
+        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+        r2i::ParameterMeta::Type::INTEGER,
+        std::make_shared<LoggingLevelAccessor>(this)),
+  PARAM("log-id", "String identification for ONNXRT environment",
+        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+        r2i::ParameterMeta::Type::STRING,
+        std::make_shared<LogIdAccessor>(this)),
+  PARAM("intra-num-threads", "Number of threads to parallelize execution within model nodes",
+        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+        r2i::ParameterMeta::Type::INTEGER,
+        std::make_shared<IntraNumThreadsAccessor>(this)),
+  PARAM("graph-optimization-level", "ONNXRT graph optimization level",
+        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+        r2i::ParameterMeta::Type::INTEGER,
+        std::make_shared<GraphOptLevelAccessor>(this)),
+  PARAM("hardware-id", "OpenVINO hardware device id",
+        r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+        r2i::ParameterMeta::Type::STRING,
+        std::make_shared<HardwareIdAccessor>(this)),
+}) {
+}
+
+RuntimeError Parameters::Configure (std::shared_ptr<r2i::IEngine> in_engine,
+                                    std::shared_ptr<r2i::IModel> in_model) {
+  RuntimeError error;
+
+  if (nullptr == in_engine) {
+    error.Set (RuntimeError::Code::NULL_PARAMETER, "Received null engine");
+    return error;
+  }
+
+  if (nullptr == in_model) {
+    error.Set (RuntimeError::Code::NULL_PARAMETER, "Received null model");
+    return error;
+  }
+
+  auto engine = std::dynamic_pointer_cast<Engine, IEngine>(in_engine);
+  if (nullptr == engine) {
+    error.Set (RuntimeError::Code::INCOMPATIBLE_ENGINE,
+               "The provided engine is not an onnxrt engine");
+    return error;
+  }
+
+  auto model = std::dynamic_pointer_cast<onnxrt::Model, IModel>(in_model);
+  if (nullptr == model) {
+    error.Set (RuntimeError::Code::INCOMPATIBLE_MODEL,
+               "The provided engine is not an onnxrt model");
+    return error;
+  }
+
+  this->engine = engine;
+  this->model = model;
+
+  return error;
+}
+
+std::shared_ptr<r2i::IEngine> Parameters::GetEngine () {
+  return this->engine;
+}
+
+
+std::shared_ptr<r2i::IModel> Parameters::GetModel () {
+  return this->model;
+}
+
+Parameters::ParamDesc Parameters::Validate (const std::string &in_parameter,
+    int type, const std::string &stype, RuntimeError &error) {
+  ParamDesc undefined = {{.name = "", .description = ""}, nullptr};
+
+  error.Clean ();
+
+  auto match = this->parameter_map.find (in_parameter);
+
+  /* The parameter wasn't found */
+  if (match == this->parameter_map.end ()) {
+    error.Set (RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               "Parameter \"" + in_parameter + "\" does not exist");
+    return undefined;
+  }
+
+  ParamDesc param = match->second;
+
+  /* The parameter is not of the correct type */
+  if (param.meta.type != type) {
+    error.Set (RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               "Parameter \"" + in_parameter + "\" is not of type " + stype);
+    return undefined;
+  }
+
+  return param;
+}
+
+RuntimeError Parameters::Get (const std::string &in_parameter, int &value) {
+  RuntimeError error;
+
+  ParamDesc param = this->Validate (in_parameter,
+                                    r2i::ParameterMeta::Type::INTEGER,
+                                    "integer", error);
+  if (error.IsError ()) {
+    return error;
+  }
+
+  auto accessor = std::dynamic_pointer_cast<IntAccessor>(param.accessor);
+
+  error = accessor->Get ();
+  if (error.IsError ()) {
+    return error;
+  }
+
+  value = accessor->value;
+  return error;
+}
+
+RuntimeError Parameters::Get (const std::string &in_parameter, double &value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::Get (const std::string &in_parameter,
+                              std::string &value) {
+  RuntimeError error;
+
+  ParamDesc param = this->Validate (in_parameter,
+                                    r2i::ParameterMeta::Type::STRING,
+                                    "string", error);
+  if (error.IsError ()) {
+    return error;
+  }
+
+  auto accessor = std::dynamic_pointer_cast<StringAccessor>(param.accessor);
+
+  error = accessor->Get ();
+  if (error.IsError ()) {
+    return error;
+  }
+
+  value = accessor->value;
+  return error;
+}
+
+RuntimeError Parameters::Set (const std::string &in_parameter, int in_value) {
+  RuntimeError error;
+
+  ParamDesc param = this->Validate (in_parameter,
+                                    r2i::ParameterMeta::Type::INTEGER,
+                                    "integer", error);
+  if (error.IsError ()) {
+    return error;
+  }
+
+  auto accessor = std::dynamic_pointer_cast<IntAccessor>(param.accessor);
+
+  accessor->value = in_value;
+  return accessor->Set ();
+}
+
+RuntimeError Parameters::Set (const std::string &in_parameter,
+                              const std::string &in_value) {
+  RuntimeError error;
+
+  ParamDesc param = this->Validate (in_parameter,
+                                    r2i::ParameterMeta::Type::STRING,
+                                    "string", error);
+  if (error.IsError ()) {
+    return error;
+  }
+
+  auto accessor = std::dynamic_pointer_cast<StringAccessor>(param.accessor);
+
+  accessor->value = in_value;
+  return accessor->Set ();
+}
+
+RuntimeError Parameters::Set (const std::string &in_parameter,
+                              double in_value) {
+  RuntimeError error;
+  return error;
+}
+
+RuntimeError Parameters::List (std::vector<ParameterMeta> &metas) {
+  for (auto &param : this->parameter_map) {
+    r2i::ParameterMeta meta = param.second.meta;
+    metas.push_back(meta);
+  }
+
+  return RuntimeError();
+}
+
+}  // namespace onnxrt_openvino
+}  // namespace r2i

--- a/r2i/onnxrt_openvino/parameters.h
+++ b/r2i/onnxrt_openvino/parameters.h
@@ -1,0 +1,157 @@
+/* Copyright (C) 2020 RidgeRun, LLC (http://www.ridgerun.com)
+ * All Rights Reserved.
+ *
+ * The contents of this software are proprietary and confidential to RidgeRun,
+ * LLC.  No part of this program may be photocopied, reproduced or translated
+ * into another programming language without prior written consent of
+ * RidgeRun, LLC.  The user is free to modify the source code after obtaining
+ * a software license from RidgeRun.  All source code changes must be provided
+ * back to RidgeRun without any encumbrance.
+*/
+
+#ifndef R2I_ONNXRT_OPENVINO_PARAMETERS_H
+#define R2I_ONNXRT_OPENVINO_PARAMETERS_H
+
+#include <memory>
+#include <string>
+#include <unordered_map>
+
+#include <r2i/iparameters.h>
+#include <r2i/runtimeerror.h>
+#include <r2i/onnxrt_openvino/engine.h>
+#include <r2i/onnxrt/model.h>
+
+namespace r2i {
+namespace onnxrt_openvino {
+
+class Parameters: public IParameters {
+ public:
+  Parameters ();
+  RuntimeError Configure (std::shared_ptr<IEngine> in_engine,
+                          std::shared_ptr<IModel> in_model) override;
+  std::shared_ptr<IEngine> GetEngine () override;
+  std::shared_ptr<IModel> GetModel ( ) override;
+  RuntimeError Get (const std::string &in_parameter, int &value) override;
+  RuntimeError Get (const std::string &in_parameter, double &value) override;
+  RuntimeError Get (const std::string &in_parameter,
+                    std::string &value) override;
+  RuntimeError Set (const std::string &in_parameter,
+                    const std::string &in_value) override;
+  RuntimeError Set (const std::string &in_parameter, int in_value) override;
+  RuntimeError Set (const std::string &in_parameter, double in_value) override;
+  RuntimeError List (std::vector<ParameterMeta> &metas) override;
+
+ private:
+  std::shared_ptr <Engine> engine;
+  std::shared_ptr <onnxrt::Model> model;
+
+  friend class Accessor;
+
+  class Accessor {
+   public:
+    Accessor (Parameters *target) : target(target) {}
+    virtual RuntimeError Set () = 0;
+    virtual RuntimeError Get () = 0;
+    virtual ~Accessor() {}
+
+   public:
+    Parameters *target;
+  };
+
+  class StringAccessor : public Accessor {
+   public:
+    StringAccessor (Parameters *target) : Accessor(target) {}
+    std::string value;
+  };
+
+  class IntAccessor : public Accessor {
+   public:
+    IntAccessor (Parameters *target) : Accessor(target) {}
+    int value;
+  };
+
+  class LoggingLevelAccessor : public IntAccessor {
+   public:
+    LoggingLevelAccessor (Parameters *target) : IntAccessor(target) {}
+
+    RuntimeError Set () {
+      return target->engine->SetLoggingLevel(this->value);
+    }
+
+    RuntimeError Get () {
+      this->value = target->engine->GetLoggingLevel();
+      return RuntimeError ();
+    }
+  };
+
+  class LogIdAccessor : public StringAccessor {
+   public:
+    LogIdAccessor (Parameters *target) : StringAccessor(target) {}
+    RuntimeError Set () {
+      return target->engine->SetLogId(this->value);
+    }
+
+    RuntimeError Get () {
+      this->value = target->engine->GetLogId();
+      return RuntimeError ();
+    }
+  };
+
+  class IntraNumThreadsAccessor : public IntAccessor {
+   public:
+    IntraNumThreadsAccessor (Parameters *target) : IntAccessor(target) {}
+
+    RuntimeError Set () {
+      return target->engine->SetIntraNumThreads(this->value);
+    }
+
+    RuntimeError Get () {
+      this->value = target->engine->GetIntraNumThreads();
+      return RuntimeError ();
+    }
+  };
+
+  class GraphOptLevelAccessor : public IntAccessor {
+   public:
+    GraphOptLevelAccessor (Parameters *target) : IntAccessor(target) {}
+
+    RuntimeError Set () {
+      return target->engine->SetGraphOptLevel(this->value);
+    }
+
+    RuntimeError Get () {
+      this->value = target->engine->GetGraphOptLevel();
+      return RuntimeError ();
+    }
+  };
+
+  class HardwareIdAccessor : public StringAccessor {
+   public:
+    HardwareIdAccessor (Parameters *target) : StringAccessor(target) {}
+    RuntimeError Set () {
+      return target->engine->SetHardwareId(this->value);
+    }
+
+    RuntimeError Get () {
+      this->value = target->engine->GetHardwareId();
+      return RuntimeError ();
+    }
+  };
+
+  struct ParamDesc {
+    ParameterMeta meta;
+    std::shared_ptr<Accessor> accessor;
+  };
+
+  typedef std::unordered_map<std::string, ParamDesc> ParamMap;
+  const ParamMap parameter_map;
+
+  ParamDesc Validate (const std::string &in_parameter, int type,
+                      const std::string &stype, RuntimeError &error);
+
+};
+
+}  // namespace onnxrt_openvino
+}  // namespace r2i
+
+#endif //R2I_ONNXRT_OPENVINO_PARAMETERS_H

--- a/r2i/onnxrt_openvino/parameters.h
+++ b/r2i/onnxrt_openvino/parameters.h
@@ -19,7 +19,6 @@
 #include <r2i/iparameters.h>
 #include <r2i/runtimeerror.h>
 #include <r2i/onnxrt_openvino/engine.h>
-#include <r2i/onnxrt/model.h>
 #include <r2i/onnxrt/parameters.h>
 
 namespace r2i {
@@ -31,7 +30,6 @@ class Parameters: public r2i::onnxrt::Parameters {
   RuntimeError Configure (std::shared_ptr<IEngine> in_engine,
                           std::shared_ptr<IModel> in_model) override;
   std::shared_ptr<IEngine> GetEngine () override;
-  std::shared_ptr<IModel> GetModel ( ) override;
   RuntimeError Get (const std::string &in_parameter, int &value) override;
   RuntimeError Get (const std::string &in_parameter, double &value) override;
   RuntimeError Get (const std::string &in_parameter,
@@ -44,7 +42,6 @@ class Parameters: public r2i::onnxrt::Parameters {
 
  private:
   std::shared_ptr <Engine> engine;
-  std::shared_ptr <onnxrt::Model> model;
 
   friend class Accessor;
 

--- a/r2i/onnxrt_openvino/parameters.h
+++ b/r2i/onnxrt_openvino/parameters.h
@@ -20,11 +20,12 @@
 #include <r2i/runtimeerror.h>
 #include <r2i/onnxrt_openvino/engine.h>
 #include <r2i/onnxrt/model.h>
+#include <r2i/onnxrt/parameters.h>
 
 namespace r2i {
 namespace onnxrt_openvino {
 
-class Parameters: public IParameters {
+class Parameters: public r2i::onnxrt::Parameters {
  public:
   Parameters ();
   RuntimeError Configure (std::shared_ptr<IEngine> in_engine,
@@ -144,11 +145,17 @@ class Parameters: public IParameters {
   };
 
   typedef std::unordered_map<std::string, ParamDesc> ParamMap;
-  const ParamMap parameter_map;
+  ParamMap parameter_map;
 
   ParamDesc Validate (const std::string &in_parameter, int type,
                       const std::string &stype, RuntimeError &error);
 
+  ParameterMeta hardware_id_meta = {
+    .name = "hardware-id",
+    .description = "OpenVINO hardware device id",
+    .flags = r2i::ParameterMeta::Flags::READWRITE | r2i::ParameterMeta::Flags::WRITE_BEFORE_START,
+    .type = r2i::ParameterMeta::Type::STRING
+  };
 };
 
 }  // namespace onnxrt_openvino

--- a/r2i/onnxrt_openvino/parameters.h
+++ b/r2i/onnxrt_openvino/parameters.h
@@ -52,7 +52,7 @@ class Parameters: public r2i::onnxrt::Parameters {
     virtual RuntimeError Get () = 0;
     virtual ~Accessor() {}
 
-   public:
+   protected:
     Parameters *target;
   };
 

--- a/r2i/tensorflow/parameters.h
+++ b/r2i/tensorflow/parameters.h
@@ -64,7 +64,7 @@ class Parameters : public IParameters {
     virtual RuntimeError Get () = 0;
     virtual ~Accessor() {}
 
-   public:
+   protected:
     Parameters *target;
   };
 

--- a/r2i/tensorrt/parameters.h
+++ b/r2i/tensorrt/parameters.h
@@ -64,7 +64,7 @@ class Parameters : public IParameters {
     virtual RuntimeError Get () = 0;
     virtual ~Accessor() {}
 
-   public:
+   protected:
     Parameters *target;
   };
 

--- a/r2i/tflite/parameters.h
+++ b/r2i/tflite/parameters.h
@@ -67,7 +67,7 @@ class Parameters: public IParameters {
     virtual ~ Accessor () {
     }
 
-   public:
+   protected:
     Parameters *target;
   };
 

--- a/tests/unit/r2i/Makefile.am
+++ b/tests/unit/r2i/Makefile.am
@@ -65,6 +65,10 @@ if HAVE_ONNXRT
 SUBDIRS += onnxrt
 endif
 
+if HAVE_ONNXRT_OPENVINO
+SUBDIRS += onnxrt_openvino
+endif
+
 if HAVE_TENSORFLOW
 SUBDIRS += tensorflow
 endif

--- a/tests/unit/r2i/meson.build
+++ b/tests/unit/r2i/meson.build
@@ -20,6 +20,10 @@ if cdata.get('HAVE_ONNXRT') == true
   subdir('onnxrt')
 endif
 
+if cdata.get('HAVE_ONNXRT_OPENVINO') == true
+  subdir('onnxrt_openvino')
+endif
+
 if cdata.get('HAVE_TENSORFLOW') == true
   subdir('tensorflow')
 endif

--- a/tests/unit/r2i/onnxrt/parameters.cc
+++ b/tests/unit/r2i/onnxrt/parameters.cc
@@ -280,7 +280,7 @@ TEST (OnnxrtParameters, SetAndGetIntraNumThreads) {
   LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
 
   /* Value different from the default */
-  in_value = 0;
+  in_value = 1;
   error = parameters.Set("intra-num-threads", in_value);
 
   LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());

--- a/tests/unit/r2i/onnxrt_openvino/Makefile.am
+++ b/tests/unit/r2i/onnxrt_openvino/Makefile.am
@@ -11,20 +11,14 @@
 AM_DEFAULT_SOURCE_EXT = .cc
 
 if ENABLE_TESTS
-if HAVE_ONNXRT
+if HAVE_ONNXRT_OPENVINO
 
 TESTS =                   \
-        engine            \
-        frame             \
-        frameworkfactory  \
-        loader            \
-        model             \
-        parameters        \
-        prediction
+        parameters
 
 check_PROGRAMS=$(TESTS)
 
-endif # HAVE_ONNXRT
+endif # HAVE_ONNXRT_OPENVINO
 endif # ENABLE_TESTS
 
 if ENABLE_CODE_COVERAGE
@@ -39,12 +33,14 @@ AM_CXXFLAGS =                       \
         $(RR_CXXFLAGS)              \
         $(TESTS_CFLAGS)             \
         $(ONNXRT_CFLAGS)            \
+        $(ONNXRT_OPENVINO_CFLAGS)   \
         $(CODE_COVERAGE_CXXFLAGS)
 
 AM_CFLAGS =                         \
         $(RR_CFLAGS)                \
         $(TESTS_CFLAGS)             \
         $(ONNXRT_CFLAGS)            \
+        $(ONNXRT_OPENVINO_CFLAGS)   \
         $(CODE_COVERAGE_CFLAGS)
 
 AM_CPPFLAGS =                       \
@@ -54,6 +50,7 @@ AM_CPPFLAGS =                       \
 AM_LDFLAGS =                        \
         $(RR_LIBS)                  \
         $(ONNXRT_LIBS)              \
+        $(ONNXRT_OPENVINO_LIBS)     \
         $(TESTS_LIBS)               \
         $(CODE_COVERAGE_LIBS)       \
         $(top_builddir)/r2i/libr2inference-@RR_PACKAGE_VERSION@.la

--- a/tests/unit/r2i/onnxrt_openvino/Makefile.am
+++ b/tests/unit/r2i/onnxrt_openvino/Makefile.am
@@ -13,8 +13,7 @@ AM_DEFAULT_SOURCE_EXT = .cc
 if ENABLE_TESTS
 if HAVE_ONNXRT_OPENVINO
 
-TESTS =                   \
-        parameters
+TESTS = parameters
 
 check_PROGRAMS=$(TESTS)
 

--- a/tests/unit/r2i/onnxrt_openvino/meson.build
+++ b/tests/unit/r2i/onnxrt_openvino/meson.build
@@ -1,0 +1,21 @@
+lib_onnxrt_tests = [
+  ['parameters.cc'],
+]
+
+# Build and run tests
+foreach t : lib_onnxrt_tests
+  fname = t[0]
+  test_name = fname.split('.')[0].underscorify()
+
+  exe = executable(test_name, fname,
+      include_directories : [configinc],
+      dependencies : [r2inference_lib_dep, tests_dep],
+  )
+
+  # Run tests
+  test(test_name, exe,
+       args : '-p',
+       timeout : 60,
+       workdir : meson.current_build_dir())
+
+endforeach

--- a/tests/unit/r2i/onnxrt_openvino/parameters.cc
+++ b/tests/unit/r2i/onnxrt_openvino/parameters.cc
@@ -1,0 +1,467 @@
+/* Copyright (C) 2020 RidgeRun, LLC (http://www.ridgerun.com)
+ * All Rights Reserved.
+ *
+ * The contents of this software are proprietary and confidential to RidgeRun,
+ * LLC.  No part of this program may be photocopied, reproduced or translated
+ * into another programming language without prior written consent of
+ * RidgeRun, LLC.  The user is free to modify the source code after obtaining
+ * a software license from RidgeRun.  All source code changes must be provided
+ * back to RidgeRun without any encumbrance.
+*/
+
+#include <r2i/r2i.h>
+#include <r2i/onnxrt/model.h>
+#include <r2i/onnxrt/engine.h>
+#include <r2i/onnxrt_openvino/engine.h>
+#include <r2i/onnxrt_openvino/parameters.h>
+
+#include <CppUTest/CommandLineTestRunner.h>
+#include <CppUTest/TestHarness.h>
+
+namespace mock {
+class Model : public r2i::IModel {
+ public:
+  Model () {}
+  r2i::RuntimeError Start (const std::string &name) {
+    return r2i::RuntimeError();
+  }
+};
+
+class Engine : public r2i::IEngine {
+ public:
+  r2i::RuntimeError Start () {
+    return r2i::RuntimeError();
+  };
+  r2i::RuntimeError Stop () {
+    return r2i::RuntimeError();
+  };
+  r2i::RuntimeError SetModel (std::shared_ptr<r2i::IModel> in_model) {
+    return r2i::RuntimeError();
+  };
+  virtual std::shared_ptr<r2i::IPrediction> Predict (std::shared_ptr<r2i::IFrame>
+      in_frame, r2i::RuntimeError &error) { return nullptr; }
+};
+}
+
+namespace r2i {
+
+RuntimeError r2i::onnxrt::Engine::Start () {
+  RuntimeError error;
+  this->state = State::STARTED;
+  return error;
+}
+
+namespace onnxrt_openvino {
+
+Engine::Engine ()  { }
+
+}
+}
+
+TEST_GROUP (OnnxrtOpenVinoParameters) {
+};
+
+TEST (OnnxrtOpenVinoParameters, ConfigureIncompatibleEngine) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+
+  std::shared_ptr<r2i::IEngine> engine(new mock::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  CHECK_TEXT (error.IsError(), error.GetDescription().c_str());
+  LONGS_EQUAL (r2i::RuntimeError::Code::INCOMPATIBLE_ENGINE, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, ConfigureIncompatibleModel) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new mock::Model);
+
+  error = parameters.Configure(engine, model);
+
+  CHECK_TEXT (error.IsError(), error.GetDescription().c_str());
+  LONGS_EQUAL (r2i::RuntimeError::Code::INCOMPATIBLE_MODEL, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, ConfigureNullEngine) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(nullptr, model);
+
+  CHECK_TEXT (error.IsError(), error.GetDescription().c_str());
+  LONGS_EQUAL (r2i::RuntimeError::Code::NULL_PARAMETER, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, ConfigureNullModel) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+
+  error = parameters.Configure(engine, nullptr);
+
+  CHECK_TEXT (error.IsError(), error.GetDescription().c_str());
+  LONGS_EQUAL (r2i::RuntimeError::Code::NULL_PARAMETER, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, ConfigureSuccess) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetAndGetEngine) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  std::shared_ptr<r2i::IEngine> internalEngine = parameters.GetEngine();
+
+  POINTERS_EQUAL(internalEngine.get(), engine.get());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetUndefinedIntegerParameter) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  value = 0;
+  error = parameters.Set("undefined-parameter", value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, GetUndefinedIntegerParameter) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("undefined-parameter", value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetUndefinedStringParameter) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  std::string value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  value = "test";
+  error = parameters.Set("undefined-parameter", value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, GetUndefinedStringParameter) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  std::string value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("undefined-parameter", value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetAndGetLogId) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  std::string in_value;
+  std::string out_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = "test";
+  error = parameters.Set("log-id", in_value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("log-id", out_value);
+
+  STRCMP_EQUAL(in_value.c_str(), out_value.c_str());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetAndGetLoggingLevel) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int in_value;
+  int out_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = 0;
+  error = parameters.Set("logging-level", in_value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("logging-level", out_value);
+
+  LONGS_EQUAL(in_value, out_value);
+}
+
+TEST (OnnxrtOpenVinoParameters, SetAndGetIntraNumThreads) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int in_value;
+  int out_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = 1;
+  error = parameters.Set("intra-num-threads", in_value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("intra-num-threads", out_value);
+
+  LONGS_EQUAL(in_value, out_value);
+}
+
+TEST (OnnxrtOpenVinoParameters, SetAndGetGraphOptLevel) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int in_value;
+  int out_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = 1;
+  error = parameters.Set("graph-optimization-level", in_value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("graph-optimization-level", out_value);
+
+  LONGS_EQUAL(in_value, out_value);
+}
+
+TEST (OnnxrtOpenVinoParameters, SetAndGetHardwareId) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  std::string in_value;
+  std::string out_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = parameters.Configure(engine, model);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = "test";
+  error = parameters.Set("hardware-id", in_value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Get("hardware-id", out_value);
+
+  STRCMP_EQUAL(in_value.c_str(), out_value.c_str());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetLogIdAtWrongEngineState) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  std::string in_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = engine->Start();
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = "test";
+  error = parameters.Set("log-id", in_value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::WRONG_ENGINE_STATE, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetLoggingLevelAtWrongEngineState) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int in_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = engine->Start();
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = 0;
+  error = parameters.Set("logging-level", in_value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::WRONG_ENGINE_STATE, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetIntraNumThreadsAtWrongEngineState) {
+  r2i::RuntimeError error;
+  r2i::onnxrt::Parameters parameters;
+  int in_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = engine->Start();
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = 0;
+  error = parameters.Set("intra-num-threads", in_value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::WRONG_ENGINE_STATE, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetGraphOptLevelAtWrongEngineState) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int in_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = engine->Start();
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = 2;
+  error = parameters.Set("graph-optimization-level", in_value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::WRONG_ENGINE_STATE, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetHardwareIdAtWrongEngineState) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  std::string in_value;
+
+  std::shared_ptr<r2i::IEngine> engine(new r2i::onnxrt_openvino::Engine);
+  std::shared_ptr<r2i::IModel> model(new r2i::onnxrt::Model);
+
+  error = engine->Start();
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  error = parameters.Configure(engine, model);
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+
+  /* Value different from the default */
+  in_value = "test";
+  error = parameters.Set("hardware-id", in_value);
+  LONGS_EQUAL (r2i::RuntimeError::Code::WRONG_ENGINE_STATE, error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, SetWrongType) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int value = 0;
+
+  error = parameters.Set("log-id", value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, GetWrongType) {
+  r2i::RuntimeError error;
+  r2i::onnxrt_openvino::Parameters parameters;
+  int value = 0;
+
+  error = parameters.Get("log-id", value);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::INVALID_FRAMEWORK_PARAMETER,
+               error.GetCode ());
+}
+
+TEST (OnnxrtOpenVinoParameters, GetList) {
+  r2i::RuntimeError error;
+  r2i::onnxrt::Parameters parameters;
+  std::vector<r2i::ParameterMeta> desc;
+
+  error = parameters.List (desc);
+
+  LONGS_EQUAL (r2i::RuntimeError::Code::EOK, error.GetCode ());
+}
+
+int main (int ac, char **av) {
+  return CommandLineTestRunner::RunAllTests (ac, av);
+}


### PR DESCRIPTION
Changes summary:

* Add parameter class (and tests) for ONNXRT OpenVINO backend. Meta information is refactored from the base class, most of the methods can not be reused because the base class implementation is based on a friend class Accesor member and friendship can not be inherited in C++. This limits greatly the possibility to refactor code and instead of rewriting the base class I opted for overrriding the methods in the derived class.
* Change default value of intra_num_threads property in ONNXRT engine, from 1 to 0. I feel this change is preferable since for ONNXRT (and execution providers) there is a better performance when this property is to 0 instead of 1.