### PR TITLE
Hotfix/rename tensorrt datatype field

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -10,7 +10,7 @@
 
 # Initialize autoconf.
 AC_PREREQ([2.69])
-AC_INIT([RidgeRun inference library],[0.10.0],[https://github.com/RidgeRun/r2inference/issues],[r2inference])
+AC_INIT([RidgeRun inference library],[0.10.1],[https://github.com/RidgeRun/r2inference/issues],[r2inference])
 
 # Initialize our build utils
 RR_INIT

--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('r2inference', ['cpp'], default_options : ['cpp_std=c++11'],
-  version : '0.10.0',
+  version : '0.10.1',
   meson_version : '>= 0.50',)
 
 # Set project information

--- a/r2i/preprocessing/Makefile.am
+++ b/r2i/preprocessing/Makefile.am
@@ -24,21 +24,33 @@ libnormalize_la_SOURCES =                     \
 
 libnormalize_inceptionv1_la_SOURCES =         \
     normalize_inceptionv1.cc
+libnormalize_inceptionv1_la_LIBADD =          \
+    $(noinst_LTLIBRARIES)
 
 libnormalize_inceptionv3_la_SOURCES =         \
     normalize_inceptionv3.cc
+libnormalize_inceptionv3_la_LIBADD =          \
+    $(noinst_LTLIBRARIES)
 
 libnormalize_resnet50v1_la_SOURCES =          \
     normalize_resnet50v1.cc
+libnormalize_resnet50v1_la_LIBADD =           \
+    $(noinst_LTLIBRARIES)
 
 libnormalize_tinyyolov2_la_SOURCES =          \
     normalize_tinyyolov2.cc
+libnormalize_tinyyolov2_la_LIBADD =           \
+    $(noinst_LTLIBRARIES)
 
 libnormalize_tinyyolov3_la_SOURCES =          \
     normalize_tinyyolov3.cc
+libnormalize_tinyyolov3_la_LIBADD =           \
+    $(noinst_LTLIBRARIES)
 
 libnormalize_facenetv1_la_SOURCES =           \
     normalize_facenetv1.cc
+libnormalize_facenetv1_la_LIBADD =            \
+    $(noinst_LTLIBRARIES)
 
 AM_CPPFLAGS =                                 \
     $(RR_CPPFLAGS)                            \
@@ -58,9 +70,7 @@ AM_CXXFLAGS =                                 \
 AM_LIBADD =                                   \
     $(RR_LIBS)                                \
     $(CODE_COVERAGE_LIBS)                     \
-    $(GLIB_LIBS)                              \
-    $(GMODULE_LIBS)                           \
-    $(top_builddir)/r2i/preprocessing/libnormalize.la
+    $(GMODULE_LIBS)
 
 #Indicate libtool this is a module (dlopened library)
 AM_CPPFLAGS_LDFLAGS =                         \

--- a/r2i/tensorrt/frame.cc
+++ b/r2i/tensorrt/frame.cc
@@ -20,7 +20,7 @@ namespace tensorrt {
 Frame::Frame () :
   frame_data(nullptr), frame_width(0), frame_height(0),
   frame_format(ImageFormat::Id::UNKNOWN_FORMAT),
-  datatype(DataType::Id::UNKNOWN_DATATYPE) {
+  data_type(DataType::Id::UNKNOWN_DATATYPE) {
 }
 
 RuntimeError Frame::Configure (void *in_data, int width,

--- a/tests/unit/r2i/onnxrt/parameters.cc
+++ b/tests/unit/r2i/onnxrt/parameters.cc
@@ -47,7 +47,9 @@ class Engine : public r2i::IEngine {
 namespace r2i {
 namespace onnxrt {
 
-Engine::Engine ()  { }
+Engine::Engine ()  {
+  this->state = State::STOPPED;
+}
 RuntimeError Engine::Start () {
   RuntimeError error;
   this->state = State::STARTED;

--- a/tests/unit/r2i/onnxrt_openvino/parameters.cc
+++ b/tests/unit/r2i/onnxrt_openvino/parameters.cc
@@ -47,7 +47,9 @@ class Engine : public r2i::IEngine {
 namespace r2i {
 namespace onnxrt {
 
-Engine::Engine ()  {}
+Engine::Engine ()  {
+  this->state = State::STOPPED;
+}
 RuntimeError Engine::Start () {
   RuntimeError error;
   this->state = State::STARTED;


### PR DESCRIPTION
This fixes the issues of:

- TensorRT compilation
- ONNXRT failing tests
- Preprocessing modules linking